### PR TITLE
Fix GL error spam on invalid key

### DIFF
--- a/src/java/org/obsidian/client/utils/keyboard/Keyboard.java
+++ b/src/java/org/obsidian/client/utils/keyboard/Keyboard.java
@@ -186,6 +186,7 @@ public enum Keyboard implements IWindow {
     }
 
     public static boolean isKeyDown(int keyCode) {
+        if (keyCode < 0) return false;
         return InputMappings.isKeyDown(IMinecraft.mc.getMainWindow().getHandle(), keyCode);
     }
 
@@ -194,6 +195,7 @@ public enum Keyboard implements IWindow {
     }
 
     public boolean isKeyDown() {
+        if (this.key < 0) return false;
         return InputMappings.isKeyDown(IMinecraft.mc.getMainWindow().getHandle(), this.key);
     }
 }


### PR DESCRIPTION
## Summary
- avoid calling GLFW with invalid key codes

## Testing
- `gradle test` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_684708f5346c8327b8910f828cfd6d39