### PR TITLE
Modernize ClickGUI categories

### DIFF
--- a/src/java/org/obsidian/client/screen/clickgui/component/category/CategoryComponent.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/category/CategoryComponent.java
@@ -12,6 +12,8 @@ import org.obsidian.client.screen.clickgui.component.WindowComponent;
 import org.obsidian.client.screen.clickgui.component.module.ModuleComponent;
 import org.obsidian.client.utils.math.Mathf;
 import org.obsidian.client.utils.other.Instance;
+import org.obsidian.client.utils.animation.Animation;
+import org.obsidian.client.utils.animation.util.Easings;
 import org.obsidian.client.utils.render.color.ColorUtil;
 import org.obsidian.client.utils.render.draw.RenderUtil;
 import org.obsidian.client.utils.render.draw.Round;
@@ -27,6 +29,12 @@ public class CategoryComponent extends WindowComponent {
     private final List<ModuleComponent> moduleComponents = new ArrayList<>();
     private float moduleHeight = 0;
     private final float margin = 5;
+    private boolean expanded = true;
+    private final Animation openAnimation = new Animation();
+
+    public float getModuleHeight() {
+        return moduleHeight * openAnimation.getValue();
+    }
 
     public CategoryComponent(Category category, ClickGuiScreen clickGui) {
         this.category = category;
@@ -48,17 +56,20 @@ public class CategoryComponent extends WindowComponent {
     @Override
     public void init() {
         moduleComponents.forEach(ModuleComponent::init);
+        openAnimation.set(expanded ? 1F : 0F);
     }
 
     @Override
     public void render(MatrixStack matrix, int mouseX, int mouseY, float partialTicks) {
+        openAnimation.update();
         Theme theme = Theme.getInstance();
-//        theme.drawClientRect(matrix, position.x, position.y, size.x, size.y + moduleHeight, alphaPC(), 4);
+
+        float animHeight = moduleHeight * openAnimation.getValue();
 
         float cx = (float) Mathf.step(position.x, 0.5);
         float cy = (float) Mathf.step(position.y, 0.5);
         float cwidth = (float) Mathf.step(size.x, 0.5);
-        float cheight = (float) Mathf.step(size.y + moduleHeight, 0.5);
+        float cheight = (float) Mathf.step(size.y + animHeight, 0.5);
         float cradius = 4;
 
         RenderUtil.Shadow.drawShadow(matrix, cx - cradius / 2, cy - cradius / 2, cwidth + cradius, cheight + cradius, 10, ColorUtil.replAlpha(theme.shadowColor(), (float) Math.pow(alphaPC(), 3)));
@@ -71,7 +82,9 @@ public class CategoryComponent extends WindowComponent {
         for (ModuleComponent component : moduleComponents) {
             if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
             component.position().set(position.x, position.y + size.y + offset);
-            component.render(matrix, mouseX, mouseY, partialTicks);
+            if (openAnimation.getValue() > 0F) {
+                component.render(matrix, mouseX, mouseY, partialTicks);
+            }
             offset += (float) (component.size().y + (component.expandAnimation().getValue() * component.getSettingHeight()));
         }
         moduleHeight = offset;
@@ -79,6 +92,12 @@ public class CategoryComponent extends WindowComponent {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (isHover(mouseX, mouseY, position.x, position.y, size.x, size.y) && isLClick(button)) {
+            expanded = !expanded;
+            openAnimation.run(expanded ? 1F : 0F, 0.25, Easings.QUART_OUT);
+            return true;
+        }
+
         for (ModuleComponent component : moduleComponents) {
             if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
             component.mouseClicked(mouseX, mouseY, button);
@@ -88,36 +107,44 @@ public class CategoryComponent extends WindowComponent {
 
     @Override
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        for (ModuleComponent component : moduleComponents) {
-            if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
-            component.mouseReleased(mouseX, mouseY, button);
+        if (openAnimation.getValue() > 0F) {
+            for (ModuleComponent component : moduleComponents) {
+                if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
+                component.mouseReleased(mouseX, mouseY, button);
+            }
         }
         return false;
     }
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        for (ModuleComponent component : moduleComponents) {
-            if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
-            component.keyPressed(keyCode, scanCode, modifiers);
+        if (openAnimation.getValue() > 0F) {
+            for (ModuleComponent component : moduleComponents) {
+                if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
+                component.keyPressed(keyCode, scanCode, modifiers);
+            }
         }
         return false;
     }
 
     @Override
     public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
-        for (ModuleComponent component : moduleComponents) {
-            if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
-            component.keyReleased(keyCode, scanCode, modifiers);
+        if (openAnimation.getValue() > 0F) {
+            for (ModuleComponent component : moduleComponents) {
+                if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
+                component.keyReleased(keyCode, scanCode, modifiers);
+            }
         }
         return false;
     }
 
     @Override
     public boolean charTyped(char codePoint, int modifiers) {
-        for (ModuleComponent component : moduleComponents) {
-            if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
-            component.charTyped(codePoint, modifiers);
+        if (openAnimation.getValue() > 0F) {
+            for (ModuleComponent component : moduleComponents) {
+                if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
+                component.charTyped(codePoint, modifiers);
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Summary
- add smooth opening animation for categories
- render modules only when expanded
- allow collapsing categories with left click

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68474b2c92908327ab5f94e001609c0f