### PR TITLE
Modernized theme presets

### DIFF
--- a/src/java/org/obsidian/client/managers/module/impl/client/Theme.java
+++ b/src/java/org/obsidian/client/managers/module/impl/client/Theme.java
@@ -27,14 +27,10 @@ public class Theme extends Module {
     }
 
     private final DelimiterSetting delimiter = new DelimiterSetting(this, "Цвета клиента");
-    private final ColorSetting client = new ColorSetting(this, "Клиент", ColorUtil.getColor(90, 90, 255));
-    private final ColorSetting background = new ColorSetting(this, "Задний фон", ColorUtil.getColor(20, 20, 30));
-    private final ColorSetting shadow = new ColorSetting(this, "Тень", ColorUtil.getColor(33, 33, 43));
-    private final ColorSetting text = new ColorSetting(this, "Текст", ColorUtil.getColor(150, 100, 255));
-    private final ColorSetting icon = new ColorSetting(this, "Иконки", ColorUtil.getColor(120, 60, 255));
-    private final ColorSetting secondary = new ColorSetting(this, "Второстепенный", ColorUtil.getColor(70, 70, 200));
-    private final ColorSetting tertiary = new ColorSetting(this, "Третичный", ColorUtil.getColor(50, 50, 150));
-    private final ColorSetting starColor = new ColorSetting(this, "Цвет звёздочек", ColorUtil.getColor(255, 215, 0)); // Значение по умолчанию - золотистый
+    private final ColorSetting accent = new ColorSetting(this, "Accent", ColorUtil.getColor(130, 90, 255));
+    private final ColorSetting background = new ColorSetting(this, "Background", ColorUtil.getColor(20, 20, 30));
+    private final ColorSetting text = new ColorSetting(this, "Text", ColorUtil.getColor(255, 255, 255));
+    private final ColorSetting starColor = new ColorSetting(this, "Star", ColorUtil.getColor(255, 215, 0));
     private final ListSetting<ThemeType> preset = new ListSetting<>(this, "Preset", ThemeType.values())
             .onAction(() -> applyTheme(preset.getValue()))
             .set(ThemeType.DARK);
@@ -62,7 +58,7 @@ public class Theme extends Module {
     }
 
     public int clientColor() {
-        return client.getValue();
+        return accent.getValue();
     }
 
     public int backgroundColor() {
@@ -70,7 +66,7 @@ public class Theme extends Module {
     }
 
     public int shadowColor() {
-        return shadow.getValue();
+        return ColorUtil.multDark(background.getValue(), 0.8F);
     }
 
     public int textColor() {
@@ -82,11 +78,11 @@ public class Theme extends Module {
     }
 
     public int iconColor() {
-        return icon.getValue();
+        return accent.getValue();
     }
 
     public int darkColor() {
-        return ColorUtil.multDark(client.getValue(), 0.25F);
+        return ColorUtil.multDark(accent.getValue(), 0.25F);
     }
 
     public int getSpeed() {
@@ -94,11 +90,11 @@ public class Theme extends Module {
     }
 
     public int secondaryColor() {
-        return secondary.getValue();
+        return ColorUtil.multDark(accent.getValue(), 0.75F);
     }
 
     public int tertiaryColor() {
-        return tertiary.getValue();
+        return ColorUtil.multDark(accent.getValue(), 0.5F);
     }
 
     // Новый метод для получения цвета звёздочек
@@ -107,12 +103,8 @@ public class Theme extends Module {
     }
 
     public void applyTheme(ThemeType type) {
-        client.set(type.getClientColor());
+        accent.set(type.getAccentColor());
         background.set(type.getBackgroundColor());
-        shadow.set(type.getShadowColor());
         text.set(type.getTextColor());
-        icon.set(type.getIconColor());
-        secondary.set(type.getSecondaryColor());
-        tertiary.set(type.getTertiaryColor());
     }
 }

--- a/src/java/org/obsidian/client/managers/module/impl/client/ThemeType.java
+++ b/src/java/org/obsidian/client/managers/module/impl/client/ThemeType.java
@@ -8,47 +8,27 @@ import org.obsidian.client.utils.render.color.ColorUtil;
 @RequiredArgsConstructor
 public enum ThemeType {
     DARK(
-            ColorUtil.getColor(90, 90, 255),
+            ColorUtil.getColor(130, 90, 255),
             ColorUtil.getColor(20, 20, 30),
-            ColorUtil.getColor(33, 33, 43),
-            ColorUtil.getColor(150, 100, 255),
-            ColorUtil.getColor(120, 60, 255),
-            ColorUtil.getColor(70, 70, 200),
-            ColorUtil.getColor(50, 50, 150)
+            ColorUtil.getColor(255, 255, 255)
     ),
-    CRIMSON(
-            ColorUtil.getColor(200, 40, 60),
-            ColorUtil.getColor(20, 10, 15),
-            ColorUtil.getColor(40, 15, 20),
-            ColorUtil.getColor(255, 80, 90),
-            ColorUtil.getColor(230, 70, 80),
-            ColorUtil.getColor(150, 30, 40),
-            ColorUtil.getColor(90, 20, 30)
+    MAGENTA(
+            ColorUtil.getColor(200, 40, 160),
+            ColorUtil.getColor(20, 10, 20),
+            ColorUtil.getColor(255, 210, 255)
     ),
     AQUA(
             ColorUtil.getColor(60, 180, 200),
             ColorUtil.getColor(15, 25, 30),
-            ColorUtil.getColor(25, 40, 45),
-            ColorUtil.getColor(120, 200, 220),
-            ColorUtil.getColor(100, 180, 200),
-            ColorUtil.getColor(50, 130, 150),
-            ColorUtil.getColor(30, 90, 110)
+            ColorUtil.getColor(230, 255, 255)
     ),
     LIGHT(
-            ColorUtil.getColor(180, 180, 200),
+            ColorUtil.getColor(120, 120, 160),
             ColorUtil.getColor(235, 235, 245),
-            ColorUtil.getColor(200, 200, 210),
-            ColorUtil.getColor(50, 50, 60),
-            ColorUtil.getColor(80, 80, 100),
-            ColorUtil.getColor(150, 150, 170),
-            ColorUtil.getColor(120, 120, 140)
+            ColorUtil.getColor(50, 50, 60)
     );
 
-    private final int clientColor;
+    private final int accentColor;
     private final int backgroundColor;
-    private final int shadowColor;
     private final int textColor;
-    private final int iconColor;
-    private final int secondaryColor;
-    private final int tertiaryColor;
 }

--- a/src/java/org/obsidian/client/screen/clickgui/component/Panel.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/Panel.java
@@ -13,6 +13,7 @@ import org.obsidian.client.screen.clickgui.ClickGuiScreen;
 import org.obsidian.client.screen.clickgui.component.category.CategoryComponent;
 import org.obsidian.client.screen.clickgui.component.module.ModuleComponent;
 import org.obsidian.client.utils.keyboard.Keyboard;
+import org.obsidian.client.managers.module.impl.client.Theme;
 import org.obsidian.client.utils.render.color.ColorUtil;
 import org.obsidian.client.utils.render.draw.RectUtil;
 import org.obsidian.client.utils.render.scroll.ScrollUtil;
@@ -111,7 +112,8 @@ public class Panel implements IScreen, IWindow {
 
     @Override
     public void render(MatrixStack matrix, int mouseX, int mouseY, float partialTicks) {
-        RectUtil.drawRect(matrix, 0, 0, width(), height(), ColorUtil.getColor(0, clickGui.alpha().get() / 2F));
+        int overlay = ColorUtil.replAlpha(Theme.getInstance().backgroundColor(), clickGui.alpha().get() / 1.5F);
+        RectUtil.drawRect(matrix, 0, 0, width(), height(), overlay);
 
         componentMove(matrix);
 

--- a/src/java/org/obsidian/client/screen/clickgui/component/WindowComponent.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/WindowComponent.java
@@ -57,7 +57,7 @@ public abstract class WindowComponent implements IScreen {
 
     public int accentColor() {
         Theme theme = Theme.getInstance();
-        return ColorUtil.multAlpha(theme.textColor(), alphaPC());
+        return ColorUtil.multAlpha(theme.clientColor(), alphaPC());
     }
 
     public boolean isHover(int mouseX, int mouseY) {

--- a/src/java/org/obsidian/client/screen/clickgui/component/category/CategoryComponent.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/category/CategoryComponent.java
@@ -2,6 +2,7 @@ package org.obsidian.client.screen.clickgui.component.category;
 
 import lombok.Getter;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.MainWindow;
 import net.mojang.blaze3d.matrix.MatrixStack;
 import org.obsidian.client.Obsidian;
 import org.obsidian.client.managers.module.Category;
@@ -17,6 +18,7 @@ import org.obsidian.client.utils.other.Instance;
 import org.obsidian.client.utils.render.color.ColorUtil;
 import org.obsidian.client.utils.render.draw.RenderUtil;
 import org.obsidian.client.utils.render.draw.Round;
+import org.obsidian.client.utils.render.draw.ScissorUtil;
 import org.obsidian.client.utils.render.font.Fonts;
 
 import java.util.ArrayList;
@@ -79,6 +81,9 @@ public class CategoryComponent extends WindowComponent {
         font.drawCenter(matrix, category.getName(), position.x + (size.x / 2F), position.y + (size.y / 2F) - (categoryFontSize / 2F), ColorUtil.multAlpha(theme.textColor(), alphaPC()), categoryFontSize);
 
         float offset = 0;
+        ScissorUtil.enable();
+        MainWindow window = Minecraft.getInstance().getMainWindow();
+        ScissorUtil.scissor(window, cx, cy + size.y, cwidth, animHeight);
         for (ModuleComponent component : moduleComponents) {
             if (Obsidian.inst().clickGui().searchCheck(component.getModule().getName())) continue;
             component.position().set(position.x, position.y + size.y + offset);
@@ -87,6 +92,7 @@ public class CategoryComponent extends WindowComponent {
             }
             offset += (float) (component.size().y + (component.expandAnimation().getValue() * component.getSettingHeight()));
         }
+        ScissorUtil.disable();
         moduleHeight = offset;
     }
 

--- a/src/java/org/obsidian/client/screen/clickgui/component/module/ModuleComponent.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/module/ModuleComponent.java
@@ -119,7 +119,7 @@ public class ModuleComponent extends WindowComponent {
         boolean isHover = isHover(mouseX, mouseY, position.x + append, position.y + append, size.x - (append * 2), size.y - (append * 2));
         hoverAnimation.run(binding && !script.isFinished() ? 1.5 : (isHover ? 1 : expanded ? angle : 0), 0.25, binding && !script.isFinished() ? Easings.BACK_OUT : Easings.QUAD_OUT, true);
 
-        int color = module.isEnabled() ? ColorUtil.multAlpha(Theme.getInstance().textColor(), alphaPC()) : ColorUtil.overCol(accentColor(), Color.GRAY.getRGB(), 0.75F);
+        int color = module.isEnabled() ? ColorUtil.multAlpha(Theme.getInstance().clientColor(), alphaPC()) : ColorUtil.overCol(accentColor(), Color.GRAY.getRGB(), 0.75F);
         int settingBackground = ColorUtil.multAlpha(backgroundColor(), 0.5F);
 
         if (!module.getSettings().isEmpty()) {


### PR DESCRIPTION
## Summary
- update `ThemeType` to provide minimal accent, background and text colors
- simplify `Theme` to use the new preset data and derive additional colors
- improve ClickGUI visuals: use theme background overlay, accent text, and clip overflowing module lists

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68482f4b76d88327b6d6559c88505faf