### PR TITLE
Simplify ClickGUI style

### DIFF
--- a/src/java/org/obsidian/client/managers/module/impl/client/Theme.java
+++ b/src/java/org/obsidian/client/managers/module/impl/client/Theme.java
@@ -27,13 +27,13 @@ public class Theme extends Module {
     }
 
     private final DelimiterSetting delimiter = new DelimiterSetting(this, "Цвета клиента");
-    private final ColorSetting accent = new ColorSetting(this, "Accent", ColorUtil.getColor(130, 90, 255));
-    private final ColorSetting background = new ColorSetting(this, "Background", ColorUtil.getColor(20, 20, 30));
-    private final ColorSetting text = new ColorSetting(this, "Text", ColorUtil.getColor(255, 255, 255));
-    private final ColorSetting starColor = new ColorSetting(this, "Star", ColorUtil.getColor(255, 215, 0));
+    private final ColorSetting accent = new ColorSetting(this, "Accent", ColorUtil.getColor(224, 224, 224));
+    private final ColorSetting background = new ColorSetting(this, "Background", ColorUtil.getColor(32, 32, 32));
+    private final ColorSetting text = new ColorSetting(this, "Text", ColorUtil.getColor(224, 224, 224));
+    private final ColorSetting starColor = new ColorSetting(this, "Star", ColorUtil.getColor(224, 224, 224));
     private final ListSetting<ThemeType> preset = new ListSetting<>(this, "Preset", ThemeType.values())
             .onAction(() -> applyTheme(preset.getValue()))
-            .set(ThemeType.DARK);
+            .set(ThemeType.FLAT);
 
     public Theme() {
         applyTheme(preset.getValue());
@@ -45,16 +45,16 @@ public class Theme extends Module {
         width = (float) Mathf.step(width, 0.5);
         height = (float) Mathf.step(height, 0.5);
 
-        RenderUtil.Shadow.drawShadow(matrix, x - radius / 2, y - radius / 2, width + radius, height + radius, 10, ColorUtil.replAlpha(shadowColor(), (float) Math.pow(alpha, 3)));
-        RenderUtil.Rounded.smooth(matrix, x, y, width, height, ColorUtil.replAlpha(backgroundColor(), alpha), Round.of(radius));
+        RenderUtil.Rounded.roundedRect(matrix, x, y, width, height, ColorUtil.replAlpha(backgroundColor(), alpha), Round.of(radius));
+        RenderUtil.Rounded.roundedOutline(matrix, x, y, width, height, 0.5F, ColorUtil.replAlpha(textColor(), alpha), Round.of(radius));
     }
 
     public void drawClientRect(MatrixStack matrix, float x, float y, float width, float height, float alpha) {
-        drawClientRect(matrix, x, y, width, height, alpha, 4);
+        drawClientRect(matrix, x, y, width, height, alpha, 2);
     }
 
     public void drawClientRect(MatrixStack matrix, float x, float y, float width, float height) {
-        drawClientRect(matrix, x, y, width, height, 1F, 4);
+        drawClientRect(matrix, x, y, width, height, 1F, 2);
     }
 
     public int clientColor() {

--- a/src/java/org/obsidian/client/managers/module/impl/client/ThemeType.java
+++ b/src/java/org/obsidian/client/managers/module/impl/client/ThemeType.java
@@ -7,25 +7,10 @@ import org.obsidian.client.utils.render.color.ColorUtil;
 @Getter
 @RequiredArgsConstructor
 public enum ThemeType {
-    DARK(
-            ColorUtil.getColor(130, 90, 255),
-            ColorUtil.getColor(20, 20, 30),
-            ColorUtil.getColor(255, 255, 255)
-    ),
-    MAGENTA(
-            ColorUtil.getColor(200, 40, 160),
-            ColorUtil.getColor(20, 10, 20),
-            ColorUtil.getColor(255, 210, 255)
-    ),
-    AQUA(
-            ColorUtil.getColor(60, 180, 200),
-            ColorUtil.getColor(15, 25, 30),
-            ColorUtil.getColor(230, 255, 255)
-    ),
-    LIGHT(
-            ColorUtil.getColor(120, 120, 160),
-            ColorUtil.getColor(235, 235, 245),
-            ColorUtil.getColor(50, 50, 60)
+    FLAT(
+            ColorUtil.getColor(224, 224, 224),
+            ColorUtil.getColor(32, 32, 32),
+            ColorUtil.getColor(224, 224, 224)
     );
 
     private final int accentColor;

--- a/src/java/org/obsidian/client/screen/clickgui/component/Panel.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/Panel.java
@@ -112,7 +112,7 @@ public class Panel implements IScreen, IWindow {
 
     @Override
     public void render(MatrixStack matrix, int mouseX, int mouseY, float partialTicks) {
-        int overlay = ColorUtil.replAlpha(Theme.getInstance().backgroundColor(), clickGui.alpha().get() / 1.5F);
+        int overlay = ColorUtil.getColor(32, 32, 32, clickGui.alpha().get() * 0.8F);
         RectUtil.drawRect(matrix, 0, 0, width(), height(), overlay);
 
         componentMove(matrix);

--- a/src/java/org/obsidian/client/screen/clickgui/component/category/CategoryComponent.java
+++ b/src/java/org/obsidian/client/screen/clickgui/component/category/CategoryComponent.java
@@ -72,12 +72,12 @@ public class CategoryComponent extends WindowComponent {
         float cy = (float) Mathf.step(position.y, 0.5);
         float cwidth = (float) Mathf.step(size.x, 0.5);
         float cheight = (float) Mathf.step(size.y + animHeight, 0.5);
-        float cradius = 4;
+        float cradius = 2;
 
-        RenderUtil.Shadow.drawShadow(matrix, cx - cradius / 2, cy - cradius / 2, cwidth + cradius, cheight + cradius, 10, ColorUtil.replAlpha(theme.shadowColor(), (float) Math.pow(alphaPC(), 3)));
-        RenderUtil.Rounded.smooth(matrix, cx, cy, cwidth, cheight, ColorUtil.replAlpha(backgroundColor(), alphaPC()), Round.of(cradius));
+        RenderUtil.Rounded.roundedRect(matrix, cx, cy, cwidth, cheight, ColorUtil.replAlpha(backgroundColor(), alphaPC()), Round.of(cradius));
+        RenderUtil.Rounded.roundedOutline(matrix, cx, cy, cwidth, cheight, 0.5F, ColorUtil.replAlpha(theme.textColor(), alphaPC()), Round.of(cradius));
 
-        Fonts.CLICKGUI.draw(matrix, category.getIcon(), position.x + 5, position.y + 5, ColorUtil.multAlpha(theme.iconColor(), alphaPC()), categoryFontSize);
+        Fonts.CLICKGUI.draw(matrix, category.getIcon(), position.x + 5, position.y + 5, ColorUtil.multAlpha(theme.textColor(), alphaPC()), categoryFontSize);
         font.drawCenter(matrix, category.getName(), position.x + (size.x / 2F), position.y + (size.y / 2F) - (categoryFontSize / 2F), ColorUtil.multAlpha(theme.textColor(), alphaPC()), categoryFontSize);
 
         float offset = 0;


### PR DESCRIPTION
## Summary
- flatten the theme with a single `FLAT` preset
- use light gray for accents/text and dark gray for the background
- draw panel and components without shadows or gradients
- simplify module rendering

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849e93d262483278f14c4937ae52159