### PR TITLE
Improve ClickGUI theme

### DIFF
--- a/src/java/org/obsidian/client/managers/module/impl/client/Theme.java
+++ b/src/java/org/obsidian/client/managers/module/impl/client/Theme.java
@@ -33,7 +33,7 @@ public class Theme extends Module {
     private final ColorSetting starColor = new ColorSetting(this, "Star", ColorUtil.getColor(224, 224, 224));
     private final ListSetting<ThemeType> preset = new ListSetting<>(this, "Preset", ThemeType.values())
             .onAction(() -> applyTheme(preset.getValue()))
-            .set(ThemeType.FLAT);
+            .set(ThemeType.MODERN);
 
     public Theme() {
         applyTheme(preset.getValue());

--- a/src/java/org/obsidian/client/managers/module/impl/client/ThemeType.java
+++ b/src/java/org/obsidian/client/managers/module/impl/client/ThemeType.java
@@ -11,6 +11,11 @@ public enum ThemeType {
             ColorUtil.getColor(224, 224, 224),
             ColorUtil.getColor(32, 32, 32),
             ColorUtil.getColor(224, 224, 224)
+    ),
+    MODERN(
+            ColorUtil.getColor(79, 148, 205),
+            ColorUtil.getColor(18, 18, 18),
+            ColorUtil.getColor(236, 236, 236)
     );
 
     private final int accentColor;

--- a/src/java/org/obsidian/client/screen/clickgui/ClickGuiScreen.java
+++ b/src/java/org/obsidian/client/screen/clickgui/ClickGuiScreen.java
@@ -13,6 +13,7 @@ import org.obsidian.client.api.interfaces.IMinecraft;
 import org.obsidian.client.api.interfaces.IMouse;
 import org.obsidian.client.api.interfaces.IWindow;
 import org.obsidian.client.managers.module.impl.client.ClickGui;
+import org.obsidian.client.managers.module.impl.client.Theme;
 import org.obsidian.client.managers.module.impl.render.Hud;
 import org.obsidian.client.screen.clickgui.component.Panel;
 import org.obsidian.client.screen.clickgui.component.module.ModuleComponent;
@@ -39,7 +40,8 @@ public class ClickGuiScreen extends Screen implements IMinecraft, IWindow, IMous
     private final float categoryWidth = 110, categoryHeight = 20, categoryOffset = 10;
     private final Panel panel = new Panel(this);
 
-    private final TextBox searchField = new TextBox(new Vector2f(), Fonts.SF_MEDIUM, 8, ColorUtil.getColor(255, 255, 255), TextAlign.CENTER, "Search: Ctrl + F", 0, false, false);
+    private final TextBox searchField = new TextBox(new Vector2f(), Fonts.SF_MEDIUM, 8,
+            ColorUtil.getColor(255, 255, 255), TextAlign.CENTER, "Search modules (Ctrl+F)", 0, false, false);
     private final GifRender gifRender = new GifRender(new Namespaced("texture/bat.gif"));
 
     public ClickGuiScreen() {
@@ -100,7 +102,7 @@ public class ClickGuiScreen extends Screen implements IMinecraft, IWindow, IMous
     }
 
     private void renderSearchField(MatrixStack matrixStack) {
-        searchField.setEmptyText("Search: Ctrl + F");
+        searchField.setEmptyText("Search modules (Ctrl+F)");
         float searchFieldHeight = searchField.getFontSize() * 2F;
 
         double searchFieldX = (scaled().x / 2F);
@@ -109,8 +111,8 @@ public class ClickGuiScreen extends Screen implements IMinecraft, IWindow, IMous
         float searchWidth = isSearching() ? searchField.getFont().getWidth(searchField.getText(), searchField.getFontSize()) + 10F : searchField.getFont().getWidth(searchField.getEmptyText(), searchField.getFontSize()) + 10F;
 
         searchField.position.set(searchFieldX, searchFieldY + ((searchFieldHeight / 2F) - (searchField.getFontSize() / 2F)));
-        searchField.setWidth(100);
-        searchField.setColor(ColorUtil.getColor(128, alpha.get()));
+        searchField.setWidth(searchWidth);
+        searchField.setColor(ColorUtil.replAlpha(Theme.getInstance().textColor(), (float) alpha.get()));
 
         int color = ColorUtil.getColor(0, 0, 0, alpha.get() / 2F);
         int shadowColor = ColorUtil.getColor(0, 0, 0, alpha.get() / 4F);


### PR DESCRIPTION
## Summary
- modernize ClickGUI search bar visuals
- add new `MODERN` theme preset and use it by default

## Testing
- `javac src/java/org/obsidian/client/screen/clickgui/ClickGuiScreen.java`
- `javac src/java/org/obsidian/client/managers/module/impl/client/Theme.java`


------
https://chatgpt.com/codex/tasks/task_e_684ad110b0808327aeb03d1efdd962cc