### PR TITLE
Fix missing implementations for GUI settings

### DIFF
--- a/src/java/org/obsidian/client/managers/module/settings/impl/BindSetting.java
+++ b/src/java/org/obsidian/client/managers/module/settings/impl/BindSetting.java
@@ -55,10 +55,10 @@ public class BindSetting extends Setting<Integer> {
     }
 
     public int getKey() {
-        return 0;
+        return getValue();
     }
 
     public void setKey(int i) {
-
+        set(i);
     }
 }

--- a/src/java/org/obsidian/client/managers/module/settings/impl/BooleanSetting.java
+++ b/src/java/org/obsidian/client/managers/module/settings/impl/BooleanSetting.java
@@ -60,5 +60,6 @@ public class BooleanSetting extends Setting<Boolean> {
     }
 
     public void setValue(boolean b) {
+        set(b);
     }
 }

--- a/src/java/org/obsidian/client/managers/module/settings/impl/ModeSetting.java
+++ b/src/java/org/obsidian/client/managers/module/settings/impl/ModeSetting.java
@@ -68,9 +68,10 @@ public class ModeSetting extends Setting<String> {
     }
 
     public String[] getModes() {
-        return null;
+        return values.toArray(new String[0]);
     }
 
     public void setValue(String text) {
+        set(text);
     }
 }

--- a/src/java/org/obsidian/client/managers/module/settings/impl/SliderSetting.java
+++ b/src/java/org/obsidian/client/managers/module/settings/impl/SliderSetting.java
@@ -54,17 +54,18 @@ public class SliderSetting extends Setting<Float> {
     }
 
     public double getMin() {
-        return 0;
+        return min;
     }
 
     public double getMax() {
-        return 0;
+        return max;
     }
 
     public void setValue(float clamp) {
+        set(Math.max(min, Math.min(max, clamp)));
     }
 
     public double getIncrement() {
-        return 0;
+        return increment;
     }
 }

--- a/src/java/org/obsidian/client/managers/module/settings/impl/StringSetting.java
+++ b/src/java/org/obsidian/client/managers/module/settings/impl/StringSetting.java
@@ -59,10 +59,10 @@ public class StringSetting extends Setting<String> {
     }
 
     public String getDescription() {
-        return "";
+        return getName();
     }
 
     public void setValue(String text) {
-
+        set(text);
     }
 }

--- a/src/java/org/obsidian/client/ui/dropdown/utils/DisplayUtils.java
+++ b/src/java/org/obsidian/client/ui/dropdown/utils/DisplayUtils.java
@@ -1,29 +1,56 @@
 package org.obsidian.client.ui.dropdown.utils;
 
 import net.minecraft.util.math.vector.Vector4f;
+import net.mojang.blaze3d.matrix.MatrixStack;
+import org.obsidian.client.utils.render.draw.RectUtil;
+import org.obsidian.client.utils.render.draw.RenderUtil;
+import org.obsidian.client.utils.render.draw.Round;
+import org.obsidian.client.ui.dropdown.utils.Vector4i;
 
 public class DisplayUtils {
     public static void drawShadow(float x, float y, float w, float h, float r, int c) {
+        RenderUtil.Shadow.drawShadow(new MatrixStack(), x, y, w, h, r, c);
     }
 
     public static void drawRoundedRect(float x, float y, float w, float h, float r, int c) {
+        RenderUtil.Rounded.roundedRect(new MatrixStack(), x, y, w, h, c, Round.of(r));
     }
 
     public static void drawRoundedRect(float x, float y, float w, float h, Object rounding, int c) {
+        Round round = toRound(rounding);
+        RenderUtil.Rounded.roundedRect(new MatrixStack(), x, y, w, h, c, round);
     }
 
     public static void drawRoundedRect(float x, float y, float w, float h, Object rounding, int c1, int c2, int c3, int c4) {
+        Round round = toRound(rounding);
+        RenderUtil.Rounded.roundedRect(new MatrixStack(), x, y, w, h, c1, c2, c3, c4, round);
     }
 
     public static void drawCircle(float x, float y, float r, int c) {
+        RenderUtil.Rounded.roundedRect(new MatrixStack(), x - r, y - r, r * 2, r * 2, c, Round.of(r));
     }
 
     public static void drawShadowCircle(float x, float y, float r, int c) {
+        RenderUtil.Shadow.drawShadow(new MatrixStack(), x - r, y - r, r * 2, r * 2, r, c);
     }
 
     public static void drawRectVerticalW(float x, float y, float w, float h, int c1, int c2) {
+        RectUtil.drawGradientV(new MatrixStack(), x, y, w, h, c1, c2, false);
     }
 
     public static void drawRoundedRect(float v, float y, float v1, float v2, Vector4f roundingVector, Vector4i vector4i) {
+        Round round = Round.of(roundingVector.x, roundingVector.y, roundingVector.z, roundingVector.w);
+        RenderUtil.Rounded.roundedRect(new MatrixStack(), v, y, v1, v2, vector4i.x, vector4i.y, vector4i.z, vector4i.w, round);
+    }
+
+    private static Round toRound(Object obj) {
+        if (obj instanceof Round) {
+            return Round.of((Round) obj);
+        } else if (obj instanceof Float) {
+            return Round.of((Float) obj);
+        } else if (obj instanceof Vector4f vec) {
+            return Round.of(vec.x, vec.y, vec.z, vec.w);
+        }
+        return Round.zero();
     }
 }


### PR DESCRIPTION
## Summary
- implement missing drawing helpers in `DisplayUtils`
- implement value handling for `SliderSetting`, `ModeSetting`, `BooleanSetting`, `BindSetting`, and `StringSetting`

## Testing
- `javac -classpath src/java -d /tmp/test_classes src/java/org/obsidian/client/ui/dropdown/utils/DisplayUtils.java` *(fails: package lombok does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684b1584145883278f48dfc590a42d4c